### PR TITLE
Adding support for Linux e.g xdg-open utility

### DIFF
--- a/git-open.sh
+++ b/git-open.sh
@@ -65,8 +65,18 @@ elif [ $# = 2 ]; then
   repo=$2
 fi
 
+# Detect the appropriate open command based on the operating system
+if command -v xdg-open >/dev/null 2>&1; then
+  open_cmd="xdg-open"
+elif command -v open >/dev/null 2>&1; then
+  open_cmd="open"
+else
+  echo "Error: No suitable open command found (tried xdg-open and open)"
+  exit 1
+fi
+
 if [ -n "${DEBUG:-}" ]; then
   echo $baseurl/$username/$repo
 else
-  open $baseurl/$username/$repo
+  $open_cmd $baseurl/$username/$repo
 fi


### PR DESCRIPTION
## Problem

The script currently uses the hardcoded `open` command, which only exists on macOS. 

On Linux systems, this causes the script to fail since `open` is not available by default. It's possible to create an alias in `~/.bashrc` to solve this issue

`alias open='xdg-open'`

## Solution
It would be rather nice to support Linux out of the box, without a need for any aliases.

The Script is checking if `xdg-open` is available or `open` is. If neither command is available an error will be raised.